### PR TITLE
Elasticsearch setup

### DIFF
--- a/.env.blank
+++ b/.env.blank
@@ -1,0 +1,10 @@
+
+reindex.remote.whitelist=
+REMOTE_HOST=
+REMOTE_USER=
+REMOTE_PASS=
+INDEX_NAME=
+
+LOCAL_HOST=http://elasticsearch:9200/
+LOCAL_USER=elastic
+LOCAL_PASS=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+## user
+data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,40 @@ services:
     build: api
     ports:
       - "80:80"
+
+  jupyter:
+    build:
+      context: .
+      dockerfile: jupyter/Dockerfile
+    ports:
+      - 8888:8888
+    volumes:
+      - type: bind
+        source: $PWD/jupyter/notebooks
+        target: /home/jovyan/notebooks
+    env_file: .env
+    environment:
+      - JUPYTER_ENABLE_LAB=yes
+    depends_on:
+      - elasticsearch
+    networks:
+      - elasticsearch
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.2
+    networks:
+      - elasticsearch
+    volumes:
+      - type: bind
+        source: $PWD/data/elasticsearch
+        target: /usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    env_file: .env
+    environment:
+      discovery.type: single-node
+      ES_JAVA_OPTS: -Xms3g -Xmx3g
+
+networks:
+  elasticsearch:
+    driver: bridge

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -1,0 +1,6 @@
+FROM jupyter/scipy-notebook
+
+RUN pip install pip-tools
+COPY requirements.in requirements.in
+RUN pip-compile
+RUN pip install -r requirements.txt

--- a/jupyter/notebooks/01 - getting data.ipynb
+++ b/jupyter/notebooks/01 - getting data.ipynb
@@ -1,0 +1,262 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from elasticsearch import Elasticsearch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting data\n",
+    "Before we start our search and similarity experiments, we need data. \n",
+    "\n",
+    "We're going to copy the wellcome collection image dataset from the production cluster to our local machine. Some of the elasticsearch concepts in this notebook might be a bit unclear while we run through these steps, but they should be made clearer over the next few notebooks where we'll have a populated data store to experiment in. \n",
+    "\n",
+    "We're basically going to be following [this guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/reindex-upgrade-remote.html) for reindexing data from a remote index to a local one, mirroring instructions with the [python elasticsearch library](https://elasticsearch-py.readthedocs.io/en/latest/index.html).\n",
+    "\n",
+    "## Connecting to a remote cluster\n",
+    "First we want to check that our source index exists and that the cluster it's running in is healthy etc. To connect to the cluster, we'll be making use of the variables we defined in `.env`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remote_es = Elasticsearch(\n",
+    "    hosts=os.environ['REMOTE_HOST'],\n",
+    "    http_auth=(\n",
+    "        os.environ['REMOTE_USER'],\n",
+    "        os.environ['REMOTE_PASS']\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = remote_es.search(\n",
+    "    body={\"query\": {\"match_all\": {}}},\n",
+    "    index=os.environ['INDEX_NAME']\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connecting to our local cluster\n",
+    "This is our cluster running in docker, which is connected to this jupyter container through a [bridge network](https://docs.docker.com/network/bridge/). \n",
+    "\n",
+    "The `LOCAL_HOST` variable should be something like `http://elasticsearch:9200`. Instead of using `http://localhost:9200` as we normally would when running outside of docker, we replace `localhost` with `elasticsearch`, the same name we gave to the container which our local cluster is running in."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_es = Elasticsearch(\n",
+    "    hosts=os.environ['LOCAL_HOST'],\n",
+    "    http_auth=(\n",
+    "        os.environ['LOCAL_USER'],\n",
+    "        os.environ['LOCAL_PASS']\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There's no data in here (yet) so there's nothing for us to look at. Let's print a list of the existing indexes in the cluster, just to make sure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_es.indices.get_alias(\"*\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See, nothing.\n",
+    "\n",
+    "We should create an index with the appropriate name to reindex our remote data into, and modify a couple of settings to make the reindex run faster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_es.indices.create(\n",
+    "    index=os.environ['INDEX_NAME'], \n",
+    "    body={\n",
+    "        \"settings\" : {\n",
+    "            \"refresh_interval\": -1,\n",
+    "            \"number_of_replicas\": 0\n",
+    "        },\n",
+    "    }\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's verify that that index now exists:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_es.indices.get_alias(\"*\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Great, now we have a remote and local index to work with.\n",
+    "\n",
+    "We're going to kick off a reindex from our remote cluster into our little local one. Normally, this command would run for a few seconds before timing out and cancelling the reindex. To stop that from happening, we'll set `wait_for_completion=False` so that the operation will run in the background without timing out. The command will then return a response containing a task ID, which we can use to monitor the progress of the reindex."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = local_es.reindex(\n",
+    "    body={\n",
+    "        \"source\": {\n",
+    "            \"remote\": {\n",
+    "                \"host\": os.environ['REMOTE_HOST'],\n",
+    "                \"username\": os.environ['REMOTE_USER'],\n",
+    "                \"password\": os.environ['REMOTE_PASS']\n",
+    "            },\n",
+    "            \"index\": os.environ['INDEX_NAME'],\n",
+    "        },\n",
+    "        \"dest\":{\n",
+    "            \"index\": os.environ['INDEX_NAME']\n",
+    "        },\n",
+    "    },\n",
+    "    wait_for_completion=False\n",
+    ")\n",
+    "\n",
+    "response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Monitoring the state of the reindex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_es.tasks.get(response['task'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you need to cancel the reindex at any point, run:"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "local_es.tasks.cancel(response['task'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## When the reindex finishes\n",
+    "\n",
+    "Finally, when all the data has been copied over to our local index, we need to modify the index settings again. We set a custom `refresh_interval` and `number_of_replicas` when we created the index so that the reindex would run quickly - now we should set them back to the default so that the data can actually be searched."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_es.indices.put_settings(\n",
+    "    index=os.environ['INDEX_NAME'],\n",
+    "    body={\n",
+    "        \"settings\" : {\n",
+    "            \"refresh_interval\": \"30s\",\n",
+    "            \"number_of_replicas\": 1\n",
+    "        },\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can start working seriously on search and similarity!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/jupyter/notebooks/02 - search and similarity.ipynb
+++ b/jupyter/notebooks/02 - search and similarity.ipynb
@@ -1,0 +1,479 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ada2b809-f67e-487a-b1b7-66d46a50fe31",
+   "metadata": {},
+   "source": [
+    "# Search\n",
+    "\n",
+    "Elasticsearch is a data store which is built for search. \n",
+    "\n",
+    "At its core, it runs a variant of [TF-IDF](https://en.wikipedia.org/wiki/Tf%E2%80%93idf) called [BM25](https://en.m.wikipedia.org/wiki/Okapi_BM25), and the way it stores data is built to support that algorithm's performance.\n",
+    "\n",
+    "Elasticsearch allows developers to use a mix of structured and unstructured data  to compose complex queries; _structure_ in the hierarchy of different fields, _unstructured_ data (like long strings of text) often within those fields.\n",
+    "\n",
+    "At query-time, a user's **search terms** are injected into a structured piece of JSON called a **query**. That query is run against an **index** of data, whose fields are structured according to another bit of JSON called a **mapping**. For every **document** in the index which matches the search terms (ie contains the same terms), a numeric **score** is calculated.  \n",
+    "\n",
+    "We're able to sort the search results according to their relevance, because in theory, the most relevant documents should be those with the highest score.  \n",
+    "\n",
+    "By changing parts of the query or the mapping, developers can tune the system to produce more appropriate scores, and thereby bring more relevant results to the top of the list.\n",
+    "\n",
+    "## Queries\n",
+    "\n",
+    "The simplest thing we can change is the query. Let's connect to the elasticsearch index and try that out."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13dbe7f8-846f-485f-b634-d19c88cb9327",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from elasticsearch import Elasticsearch\n",
+    "from piffle.iiif import IIIFImageClient \n",
+    "from io import BytesIO\n",
+    "import httpx\n",
+    "from PIL import Image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e77488a8-4a5b-43d0-ba88-62f3b2eea6fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_es = Elasticsearch(\n",
+    "    hosts=os.environ['LOCAL_HOST'],\n",
+    "    http_auth=(\n",
+    "        os.environ['LOCAL_USER'],\n",
+    "        os.environ['LOCAL_PASS']\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db2d3d49-59d0-49c5-a298-0dddf2e2c9a1",
+   "metadata": {},
+   "source": [
+    "## Get\n",
+    "The simplest search we can do is a straightforward GET. We tell the cluster the exact ID of the document we're looking for and the index we know it's in, and elasticsearch gives us all of the data it has about it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2dfb7028-5c51-4268-b316-d51a4999eb4c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = local_es.get(\n",
+    "    index=os.environ['INDEX_NAME'],\n",
+    "    id='agq44vu9'\n",
+    ")\n",
+    "\n",
+    "response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d825f86-020f-46d4-bb7e-90273a8ad786",
+   "metadata": {},
+   "source": [
+    "## Search\n",
+    "But elasticsearch supports a rich query syntax, and we can do much, much more than that. The simplest place to start is a [query string query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html). This contains a load of baked-in clever lexical rules (eg stemming), and will be applied to all of the fields in the mapping. For a simple index with simple search intents, this is usually the best place to start."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c29f34d9-3516-4bb2-a1fa-2aef84544710",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search_terms = \"dog\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb7ae245-bc0a-41ec-a603-02a118ea05ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = local_es.search(\n",
+    "    index=os.environ['INDEX_NAME'],\n",
+    "    body={\n",
+    "        \"query\": {\n",
+    "            \"query_string\": {\n",
+    "                \"query\": search_terms\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "932c87f1-33d5-4491-9721-ebc71f34a286",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    f\"Found {response['hits']['total']['value']} \"\n",
+    "    f\"results in {response['took'] / 1000}s\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76c0e443-d154-4ebf-bf2b-52f3c9a9c39d",
+   "metadata": {},
+   "source": [
+    "The index returned lots of matching results, sorted according to their BM25 scores. We'd expect the first result to be pretty relevant. Let's take a look at the image associated with the record"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abb6979f-11ba-4876-a5f8-1d4ece47eae7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "first_result = response['hits']['hits'][0]\n",
+    "iiif_url = first_result['_source']['state']['derivedData']['thumbnail']['url']\n",
+    "image_url = str(IIIFImageClient().init_from_url(iiif_url).size(width=500))\n",
+    "Image.open(BytesIO(httpx.get(image_url).content))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c30986a0-fea6-47b3-89bb-12b4efe5d705",
+   "metadata": {},
+   "source": [
+    "Looks like a pretty good match for our search terms to me!\n",
+    "\n",
+    "Let's try again with a different search term:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7431c04-1be3-48bc-81d4-49db6fefbc85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search_terms = \"cat\"\n",
+    "\n",
+    "response = local_es.search(\n",
+    "    index=os.environ['INDEX_NAME'],\n",
+    "    body={\n",
+    "        \"query\": {\n",
+    "            \"query_string\": {\n",
+    "                \"query\": search_terms\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "first_result = response['hits']['hits'][0]\n",
+    "iiif_url = first_result['_source']['state']['derivedData']['thumbnail']['url']\n",
+    "image_url = str(IIIFImageClient().init_from_url(iiif_url).size(width=500))\n",
+    "Image.open(BytesIO(httpx.get(image_url).content))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d223d0e-a53b-4cb2-bf09-8f62993c4124",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "first_result['_source']['source']['canonicalWork']['data']['title']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5558a97-3fd4-4b0c-a65e-4f92b47e7f9c",
+   "metadata": {},
+   "source": [
+    "Not so good. We can tweak the query to only match search terms in the title field:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01f51f81-01db-4fc1-9c31-16665e4bebe5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = local_es.search(\n",
+    "    index=os.environ['INDEX_NAME'],\n",
+    "    body={\n",
+    "        \"query\": {\n",
+    "            \"match\": {\n",
+    "                \"source.canonicalWork.data.title\": search_terms\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "\n",
+    "first_result = response['hits']['hits'][0]\n",
+    "iiif_url = first_result['_source']['state']['derivedData']['thumbnail']['url']\n",
+    "image_url = str(IIIFImageClient().init_from_url(iiif_url).size(width=500))\n",
+    "Image.open(BytesIO(httpx.get(image_url).content))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6cb9048c-1ec7-4355-8b81-4d87ffe47321",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "first_result['_source']['source']['canonicalWork']['data']['title']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7217f02-c02c-41ba-bed3-0a8c2ecd0d51",
+   "metadata": {},
+   "source": [
+    "The title's much more obviously related to the query's search terms, but the image is still seems like an odd choice. \n",
+    "\n",
+    "We can search across multiple fields:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79dfeb67-e45c-4478-a1d2-0e5f251c2b06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = local_es.search(\n",
+    "    index=os.environ['INDEX_NAME'],\n",
+    "    body={\n",
+    "        \"query\": {\n",
+    "            \"multi_match\": {\n",
+    "                \"query\": search_terms,\n",
+    "                \"fields\": [\n",
+    "                    \"source.canonicalWork.data.title\",\n",
+    "                    \"source.canonicalWork.data.description\"\n",
+    "                ]\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "\n",
+    "first_result = response['hits']['hits'][0]\n",
+    "iiif_url = first_result['_source']['state']['derivedData']['thumbnail']['url']\n",
+    "image_url = str(IIIFImageClient().init_from_url(iiif_url).size(width=500))\n",
+    "Image.open(BytesIO(httpx.get(image_url).content))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2e99532-9c53-48c9-be6f-0bd021b04dd3",
+   "metadata": {},
+   "source": [
+    "And we can add varying levels of **boost** to each field - If we believe that an image's description is more important than it's title, we can add a higher boost to that field."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffcc6870-0903-49e0-961f-9fe50b4b2fca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = local_es.search(\n",
+    "    index=os.environ['INDEX_NAME'],\n",
+    "    body={\n",
+    "        \"query\": {\n",
+    "            \"multi_match\": {\n",
+    "                \"query\": search_terms,\n",
+    "                \"fields\": [\n",
+    "                    \"source.canonicalWork.data.title^5\",\n",
+    "                    \"source.canonicalWork.data.description^20\"\n",
+    "                ]\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "\n",
+    "first_result = response['hits']['hits'][0]\n",
+    "iiif_url = first_result['_source']['state']['derivedData']['thumbnail']['url']\n",
+    "image_url = str(IIIFImageClient().init_from_url(iiif_url).size(width=500))\n",
+    "Image.open(BytesIO(httpx.get(image_url).content))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05ea3dc1-51a3-4435-9250-4bf5ab179255",
+   "metadata": {},
+   "source": [
+    "Hooray, we're finally seeing a cat! Maybe we've improved the structure of our query! Let's search again for \"dog\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "257cc46a-9359-4d18-b81f-03e3264a2c6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search_terms = \"dog\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "942bef6d-959e-4152-8514-90bb04b48674",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = local_es.search(\n",
+    "    index=os.environ['INDEX_NAME'],\n",
+    "    body={\n",
+    "        \"query\": {\n",
+    "            \"multi_match\": {\n",
+    "                \"query\": search_terms,\n",
+    "                \"fields\": [\n",
+    "                    \"source.canonicalWork.data.title^5\",\n",
+    "                    \"source.canonicalWork.data.description^20\"\n",
+    "                ]\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "\n",
+    "first_result = response['hits']['hits'][0]\n",
+    "iiif_url = first_result['_source']['state']['derivedData']['thumbnail']['url']\n",
+    "image_url = str(IIIFImageClient().init_from_url(iiif_url).size(width=500))\n",
+    "Image.open(BytesIO(httpx.get(image_url).content))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "181ad323-ab9c-485b-a204-5060014ba7f1",
+   "metadata": {},
+   "source": [
+    "Ah, again, we've lost the relevant results because the query isn't quite right. Hopefully this demonstrates the balancing act that we have to practice when tuning search - Because queries are run against the _whole_ index, we need to consider how a change will affect _everything_. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7ead3d9-bc37-4bde-a2a7-d2c2f77ddb53",
+   "metadata": {},
+   "source": [
+    "# Similarity\n",
+    "We can also run 'searches' using data from fields within the index, not supplying any new terms apart from a target work ID. These [\"more like this\"](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html) queries are used to find similar results to the query work.\n",
+    "\n",
+    "Here's the title of the original work which we'll run the query with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f7054fc-4124-4c4a-b5fb-4abe3e741bf5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_es.get(\n",
+    "    index=os.environ['INDEX_NAME'],\n",
+    "    id='agq44vu9'\n",
+    ")['_source']['source']['canonicalWork']['data']['title']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b3ad0c6-51d5-4cfa-9737-82e1e7c2052a",
+   "metadata": {},
+   "source": [
+    "Structuring the query to just look at the title, and we get a first result with a very similar title"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4ed16a4-b5fa-4fed-bfba-73fd046fdbf8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = local_es.search(\n",
+    "    index=os.environ['INDEX_NAME'],\n",
+    "    body={\n",
+    "      \"query\": {\n",
+    "        \"more_like_this\": {\n",
+    "          \"fields\": [ \"source.canonicalWork.data.title\" ],\n",
+    "          \"like\": [\n",
+    "            {\n",
+    "              \"_index\": os.environ['INDEX_NAME'],\n",
+    "              \"_id\": \"agq44vu9\"\n",
+    "            }\n",
+    "          ],\n",
+    "        }\n",
+    "      }\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "\n",
+    "first_result = response['hits']['hits'][0]\n",
+    "first_result['_source']['source']['canonicalWork']['data']['title']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72d28ecb-9ca2-46b7-a7aa-f3a8e02fe680",
+   "metadata": {},
+   "source": [
+    "and fairly similar image content as a result!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3b2f924-ad07-4966-92ef-f34ae421c4f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iiif_url = first_result['_source']['state']['derivedData']['thumbnail']['url']\n",
+    "image_url = str(IIIFImageClient().init_from_url(iiif_url).size(width=500))\n",
+    "Image.open(BytesIO(httpx.get(image_url).content))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.in
+++ b/requirements.in
@@ -1,0 +1,6 @@
+httpx
+numpy
+piffle
+scikit-image
+scikit-learn
+elasticsearch


### PR DESCRIPTION
You should be able to start this new jupyter container by running `docker compose up --build jupyter`.

To reindex data from a remote cluster you'll need to supply some credentials to the container. These will be automatically picked up, but you'll need to duplicate the `.env.blank` file and rename it `.env`, and fill it with the necessary secrets. We can go through this together on a call this week if you like.

( resolves #15 )