### PR TITLE
adds a kibana service for browsing and visualising local indicies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,17 @@ services:
       discovery.type: single-node
       ES_JAVA_OPTS: -Xms3g -Xmx3g
 
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.13.2
+    depends_on:
+      - elasticsearch
+    ports:
+      - 5601:5601
+    networks:
+      - elasticsearch
+    environment:
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+
   process_images:
     build: process_images
     depends_on:


### PR DESCRIPTION
Based on the documentation [here](https://www.elastic.co/guide/en/kibana/current/docker.html). 

Run `docker compose up --build kibana` to get it running. 

Remember to create an index pattern for each index so that it can be browsed through the "Discover" tab!